### PR TITLE
Fix getShows fallback behavior

### DIFF
--- a/src/firebase/getShows.ts
+++ b/src/firebase/getShows.ts
@@ -38,17 +38,7 @@ export async function getShows(): Promise<Show[]> {
   } catch (error) {
     console.error('❌ Firestore fetch error:', error);
 
-    // TEMP: Fallback dummy data to check display
-    return [
-      {
-        id: 'test1',
-        title: 'Test Show',
-        date: 'Tomorrow',
-        venue: 'Test Venue',
-        description: 'Just checking fallback!',
-        imageUrl: '/images/test.jpg',
-        ticketLink: '#',
-      },
-    ];
+    // Return an empty array so the UI can show a friendly message
+    return [];
   }
 }


### PR DESCRIPTION
## Summary
- remove placeholder shows when Firestore fetch fails
- keep shows page logic for empty lists

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68786e87914c832986102d37c8371465