### PR TITLE
Add blog creation page for admin

### DIFF
--- a/src/app/admin/blog/new/page.tsx
+++ b/src/app/admin/blog/new/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { signOut } from 'firebase/auth';
+import { auth } from '@/firebase/firebase.config';
+import { addBlogPost } from '@/firebase/addBlogPost';
+import WithAdminProtection from '@/components/WithAdminProtection';
+
+function NewBlogPostPage() {
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+  const [slug, setSlug] = useState('');
+  const [content, setContent] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleLogout = async () => {
+    await signOut(auth);
+    window.location.reload();
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!imageFile) {
+      setMessage('Please select an image.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await addBlogPost({ title, date, slug, content }, imageFile);
+      setMessage('Blog post added successfully.');
+      setTitle('');
+      setDate('');
+      setSlug('');
+      setContent('');
+      setImageFile(null);
+    } catch (err) {
+      console.error(err);
+      setMessage('Failed to add blog post.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto px-6 py-12">
+      <h1 className="text-2xl font-bold mb-6">Add Blog Post</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          placeholder="Title"
+          className="w-full border rounded p-2"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Date"
+          className="w-full border rounded p-2"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Slug"
+          className="w-full border rounded p-2"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          required
+        />
+        <textarea
+          placeholder="Content"
+          className="w-full border rounded p-2"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          required
+        />
+        <input
+          type="file"
+          accept="image/*"
+          className="w-full"
+          onChange={(e) => setImageFile(e.target.files?.[0] || null)}
+          required
+        />
+        <button
+          type="submit"
+          disabled={submitting}
+          className="px-4 py-2 bg-black text-white rounded disabled:opacity-50"
+        >
+          {submitting ? 'Uploading...' : 'Add Blog Post'}
+        </button>
+      </form>
+
+      {message && <p className="mt-4">{message}</p>}
+      <button
+        onClick={handleLogout}
+        className="text-sm text-blue-600 underline mt-6"
+      >
+        Log out
+      </button>
+    </div>
+  );
+}
+
+export default WithAdminProtection(NewBlogPostPage);

--- a/src/firebase/addBlogPost.ts
+++ b/src/firebase/addBlogPost.ts
@@ -1,0 +1,31 @@
+import { db, storage } from './firebase.config';
+import { collection, addDoc } from 'firebase/firestore';
+import {
+  ref,
+  uploadBytesResumable,
+  getDownloadURL,
+  type UploadTaskSnapshot,
+} from 'firebase/storage';
+
+export interface BlogPostFormData {
+  title: string;
+  date: string;
+  slug: string;
+  content: string;
+}
+
+export async function addBlogPost(data: BlogPostFormData, file: File) {
+  const storageRef = ref(storage, `posts/${Date.now()}_${file.name}`);
+  const uploadTask = uploadBytesResumable(storageRef, file);
+
+  const snapshot: UploadTaskSnapshot = await new Promise((resolve, reject) => {
+    uploadTask.on('state_changed', null, reject, () => resolve(uploadTask.snapshot));
+  });
+
+  const imageUrl = await getDownloadURL(snapshot.ref);
+
+  await addDoc(collection(db, 'posts'), {
+    ...data,
+    imageUrl,
+  });
+}


### PR DESCRIPTION
## Summary
- allow admins to create blog posts
- handle file upload and firestore logic

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build` *(fails: ESLint errors during build)*

------
https://chatgpt.com/codex/tasks/task_e_6879b47cfa148329b572fa35d1b3fdea