### PR TITLE
Add admin dashboard and login link

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import { signOut } from 'firebase/auth';
+import { auth } from '@/firebase/firebase.config';
+import WithAdminProtection from '@/components/WithAdminProtection';
+
+function AdminDashboard() {
+  const handleLogout = async () => {
+    await signOut(auth);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-12">
+      <h1 className="text-3xl font-bold mb-8">Admin Dashboard</h1>
+      <div className="grid gap-6 sm:grid-cols-3">
+        <Link
+          href="/admin/shows/new"
+          className="border rounded-lg p-6 text-center hover:bg-gray-50"
+        >
+          New Show
+        </Link>
+        <Link
+          href="/admin/workshops/new"
+          className="border rounded-lg p-6 text-center hover:bg-gray-50"
+        >
+          New Workshop
+        </Link>
+        <Link
+          href="/admin/blog/new"
+          className="border rounded-lg p-6 text-center hover:bg-gray-50"
+        >
+          New Blog Post
+        </Link>
+      </div>
+      <button
+        onClick={handleLogout}
+        className="mt-8 underline text-sm text-blue-600"
+      >
+        Log out
+      </button>
+    </div>
+  );
+}
+
+export default WithAdminProtection(AdminDashboard);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -15,7 +15,7 @@ export default function LoginPage() {
     e.preventDefault();
     try {
       await signInWithEmailAndPassword(auth, email, password);
-      router.push('/admin/shows/new'); // Redirect on success
+      router.push('/admin'); // Redirect on success to dashboard
     } catch (err: any) {
       console.error(err);
       setError(err.message);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,6 +22,9 @@ export default function Header() {
           <Link href="/blog" className="hover:underline">
             Blog
           </Link>
+          <Link href="/login" className="hover:underline">
+            Admin Login
+          </Link>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add an Admin Login link in the header navigation
- redirect logins to `/admin`
- introduce `/admin` dashboard with tiles for creating content

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6879bf615ffc8329afd8e22d01b454d1