### PR TITLE
Enable admin editing and deletion

### DIFF
--- a/src/app/admin/blog/edit/[id]/page.tsx
+++ b/src/app/admin/blog/edit/[id]/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+import { useEffect, useState, FormEvent } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import { db } from '@/firebase/firebase.config';
+import WithAdminProtection from '@/components/WithAdminProtection';
+
+function EditBlogPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+  const [slug, setSlug] = useState('');
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDoc(doc(db, 'posts', id));
+      if (snap.exists()) {
+        const data = snap.data();
+        setTitle(data.title || '');
+        setDate(data.date || '');
+        setSlug(data.slug || '');
+        setContent(data.content || '');
+      }
+      setLoading(false);
+    };
+    if (id) load();
+  }, [id]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await updateDoc(doc(db, 'posts', id), {
+      title,
+      date,
+      slug,
+      content,
+    });
+    setMessage('Post updated.');
+    router.push('/blog');
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-xl mx-auto px-6 py-12">
+      <h1 className="text-2xl font-bold mb-6">Edit Blog Post</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          placeholder="Title"
+          className="w-full border rounded p-2"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Date"
+          className="w-full border rounded p-2"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Slug"
+          className="w-full border rounded p-2"
+          value={slug}
+          onChange={e => setSlug(e.target.value)}
+          required
+        />
+        <textarea
+          placeholder="Content"
+          className="w-full border rounded p-2"
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          required
+        />
+        <button type="submit" className="px-4 py-2 bg-black text-white rounded">
+          Save
+        </button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  );
+}
+
+export default WithAdminProtection(EditBlogPage);

--- a/src/app/admin/shows/edit/[id]/page.tsx
+++ b/src/app/admin/shows/edit/[id]/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useEffect, useState, FormEvent } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import { db } from '@/firebase/firebase.config';
+import WithAdminProtection from '@/components/WithAdminProtection';
+
+function EditShowPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+  const [venue, setVenue] = useState('');
+  const [description, setDescription] = useState('');
+  const [ticketLink, setTicketLink] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDoc(doc(db, 'shows', id));
+      if (snap.exists()) {
+        const data = snap.data();
+        setTitle(data.title || '');
+        setDate(data.date || '');
+        setVenue(data.venue || '');
+        setDescription(data.description || '');
+        setTicketLink(data.ticketLink || '');
+      }
+      setLoading(false);
+    };
+    if (id) load();
+  }, [id]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await updateDoc(doc(db, 'shows', id), {
+      title,
+      date,
+      venue,
+      description,
+      ticketLink,
+    });
+    setMessage('Show updated.');
+    router.push('/shows');
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-xl mx-auto px-6 py-12">
+      <h1 className="text-2xl font-bold mb-6">Edit Show</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          placeholder="Title"
+          className="w-full border rounded p-2"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Date"
+          className="w-full border rounded p-2"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Venue"
+          className="w-full border rounded p-2"
+          value={venue}
+          onChange={e => setVenue(e.target.value)}
+          required
+        />
+        <textarea
+          placeholder="Description"
+          className="w-full border rounded p-2"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Ticket Link"
+          className="w-full border rounded p-2"
+          value={ticketLink}
+          onChange={e => setTicketLink(e.target.value)}
+          required
+        />
+        <button type="submit" className="px-4 py-2 bg-black text-white rounded">
+          Save
+        </button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  );
+}
+
+export default WithAdminProtection(EditShowPage);

--- a/src/app/admin/workshops/edit/[id]/page.tsx
+++ b/src/app/admin/workshops/edit/[id]/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useEffect, useState, FormEvent } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import { db } from '@/firebase/firebase.config';
+import WithAdminProtection from '@/components/WithAdminProtection';
+
+function EditWorkshopPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+  const [venue, setVenue] = useState('');
+  const [description, setDescription] = useState('');
+  const [signupLink, setSignupLink] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDoc(doc(db, 'workshops', id));
+      if (snap.exists()) {
+        const data = snap.data();
+        setTitle(data.title || '');
+        setDate(data.date || '');
+        setVenue(data.venue || '');
+        setDescription(data.description || '');
+        setSignupLink(data.signupLink || '');
+      }
+      setLoading(false);
+    };
+    if (id) load();
+  }, [id]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await updateDoc(doc(db, 'workshops', id), {
+      title,
+      date,
+      venue,
+      description,
+      signupLink,
+    });
+    setMessage('Workshop updated.');
+    router.push('/workshops');
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-xl mx-auto px-6 py-12">
+      <h1 className="text-2xl font-bold mb-6">Edit Workshop</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          placeholder="Title"
+          className="w-full border rounded p-2"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Date"
+          className="w-full border rounded p-2"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Venue"
+          className="w-full border rounded p-2"
+          value={venue}
+          onChange={e => setVenue(e.target.value)}
+          required
+        />
+        <textarea
+          placeholder="Description"
+          className="w-full border rounded p-2"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Signup Link"
+          className="w-full border rounded p-2"
+          value={signupLink}
+          onChange={e => setSignupLink(e.target.value)}
+          required
+        />
+        <button type="submit" className="px-4 py-2 bg-black text-white rounded">
+          Save
+        </button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  );
+}
+
+export default WithAdminProtection(EditWorkshopPage);

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,33 @@
+'use client';
 import Image from 'next/image';
 import Link from 'next/link';
-import { getBlogPosts } from '@/firebase/getBlogPosts';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/firebase/firebase.config';
+import { getBlogPosts, type BlogPost } from '@/firebase/getBlogPosts';
+import { deleteBlogPost } from '@/firebase/deleteBlogPost';
 
-export default async function BlogPage() {
-  const posts = await getBlogPosts();
+export default function BlogPage() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const data = await getBlogPosts();
+      setPosts(data);
+    })();
+    const unsub = onAuthStateChanged(auth, user => setIsAdmin(!!user));
+    return () => unsub();
+  }, []);
+
+  const handleDelete = async (id: string) => {
+    if (confirm('Are you sure you want to delete this post?')) {
+      await deleteBlogPost(id);
+      setPosts(prev => prev.filter(p => p.id !== id));
+    }
+  };
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-12">
@@ -12,11 +36,8 @@ export default async function BlogPage() {
         <p className="text-gray-500">No posts found.</p>
       ) : (
         <div className="grid gap-10">
-          {posts.map((post) => (
-            <article
-              key={post.id}
-              className="border rounded-lg overflow-hidden shadow-sm bg-white"
-            >
+          {posts.map(post => (
+            <article key={post.id} className="border rounded-lg overflow-hidden shadow-sm bg-white">
               <Image
                 src={post.imageUrl}
                 alt={post.title}
@@ -31,12 +52,15 @@ export default async function BlogPage() {
                   </Link>
                 </h2>
                 <p className="text-sm text-gray-500 mb-4">{post.date}</p>
-                <Link
-                  href={`/blog/${post.slug}`}
-                  className="text-blue-600 hover:underline"
-                >
+                <Link href={`/blog/${post.slug}`} className="text-blue-600 hover:underline">
                   Read More
                 </Link>
+                {isAdmin && (
+                  <div className="flex gap-4 mt-2">
+                    <button onClick={() => router.push(`/admin/blog/edit/${post.id}`)}>Edit</button>
+                    <button onClick={() => handleDelete(post.id)}>Delete</button>
+                  </div>
+                )}
               </div>
             </article>
           ))}

--- a/src/app/shows/page.tsx
+++ b/src/app/shows/page.tsx
@@ -1,23 +1,42 @@
-// app/shows/page.tsx
+'use client';
 import Image from 'next/image';
-import { getShows } from '@/firebase/getShows';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/firebase/firebase.config';
+import { getShows, type Show } from '@/firebase/getShows';
+import { deleteShow } from '@/firebase/deleteShow';
 
-export default async function ShowsPage() {
-  const shows = await getShows();
+export default function ShowsPage() {
+  const [shows, setShows] = useState<Show[]>([]);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const data = await getShows();
+      setShows(data);
+    })();
+    const unsub = onAuthStateChanged(auth, user => setIsAdmin(!!user));
+    return () => unsub();
+  }, []);
+
+  const handleDelete = async (id: string) => {
+    if (confirm('Are you sure you want to delete this show?')) {
+      await deleteShow(id);
+      setShows(prev => prev.filter(s => s.id !== id));
+    }
+  };
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-12">
       <h1 className="text-3xl font-bold mb-8">Upcoming Shows</h1>
-
       {shows.length === 0 ? (
         <p className="text-gray-500">No shows currently listed.</p>
       ) : (
         <div className="grid gap-10 md:grid-cols-2">
-          {shows.map((show) => (
-            <div
-              key={show.id}
-              className="border rounded-lg overflow-hidden shadow-sm bg-white"
-            >
+          {shows.map(show => (
+            <div key={show.id} className="border rounded-lg overflow-hidden shadow-sm bg-white">
               <Image
                 src={show.imageUrl}
                 alt={show.title}
@@ -38,11 +57,17 @@ export default async function ShowsPage() {
                 >
                   Get Tickets
                 </a>
+                {isAdmin && (
+                  <div className="flex gap-4 mt-2">
+                    <button onClick={() => router.push(`/admin/shows/edit/${show.id}`)}>Edit</button>
+                    <button onClick={() => handleDelete(show.id)}>Delete</button>
+                  </div>
+                )}
               </div>
             </div>
           ))}
         </div>
       )}
     </div>
-  ); 
+  );
 }

--- a/src/firebase/deleteBlogPost.ts
+++ b/src/firebase/deleteBlogPost.ts
@@ -1,0 +1,6 @@
+import { db } from './firebase.config';
+import { doc, deleteDoc } from 'firebase/firestore';
+
+export async function deleteBlogPost(id: string) {
+  await deleteDoc(doc(db, 'posts', id));
+}

--- a/src/firebase/deleteShow.ts
+++ b/src/firebase/deleteShow.ts
@@ -1,0 +1,6 @@
+import { db } from './firebase.config';
+import { doc, deleteDoc } from 'firebase/firestore';
+
+export async function deleteShow(id: string) {
+  await deleteDoc(doc(db, 'shows', id));
+}

--- a/src/firebase/deleteWorkshop.ts
+++ b/src/firebase/deleteWorkshop.ts
@@ -1,0 +1,6 @@
+import { db } from './firebase.config';
+import { doc, deleteDoc } from 'firebase/firestore';
+
+export async function deleteWorkshop(id: string) {
+  await deleteDoc(doc(db, 'workshops', id));
+}


### PR DESCRIPTION
## Summary
- add helpers to delete Firestore docs
- show edit and delete buttons for admins on content lists
- add pages to edit existing shows, workshops and blog posts

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6879ffd85e10832995fa6ab9d424b201