### PR TITLE
Design makeover: add brand colors and AOS

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -7,6 +7,8 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from '@/firebase/firebase.config';
 import { getBlogPosts, type BlogPost } from '@/firebase/getBlogPosts';
 import { deleteBlogPost } from '@/firebase/deleteBlogPost';
+import AOS from 'aos';
+import 'aos/dist/aos.css';
 
 export default function BlogPage() {
   const [posts, setPosts] = useState<BlogPost[]>([]);
@@ -14,6 +16,7 @@ export default function BlogPage() {
   const router = useRouter();
 
   useEffect(() => {
+    AOS.init({ duration: 800 });
     (async () => {
       const data = await getBlogPosts();
       setPosts(data);
@@ -37,7 +40,11 @@ export default function BlogPage() {
       ) : (
         <div className="grid gap-10">
           {posts.map(post => (
-            <article key={post.id} className="border rounded-lg overflow-hidden shadow-sm bg-white">
+            <article
+              key={post.id}
+              className="border rounded-lg overflow-hidden shadow-sm bg-white card"
+              data-aos="fade-up"
+            >
               <Image
                 src={post.imageUrl}
                 alt={post.title}
@@ -57,8 +64,18 @@ export default function BlogPage() {
                 </Link>
                 {isAdmin && (
                   <div className="flex gap-4 mt-2">
-                    <button onClick={() => router.push(`/admin/blog/edit/${post.id}`)}>Edit</button>
-                    <button onClick={() => handleDelete(post.id)}>Delete</button>
+                    <button
+                      onClick={() => router.push(`/admin/blog/edit/${post.id}`)}
+                      className="px-4 py-1 bg-goat-yellow text-black rounded-md text-sm hover:bg-yellow-400 transition"
+                    >
+                      ✏️ Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(post.id)}
+                      className="px-4 py-1 bg-red-500 text-white rounded-md text-sm hover:bg-red-600 transition"
+                    >
+                      🗑️ Delete
+                    </button>
                   </div>
                 )}
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,27 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: 'DM Sans', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s ease-in-out;
+}
+
+.goat-watermark {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  font-size: 2rem;
+  opacity: 0.2;
+  pointer-events: none;
 }
 
 h1,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,10 +22,11 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="bg-white text-black min-h-screen flex flex-col">
+      <body className="bg-goat-blue text-white min-h-screen flex flex-col">
         <Header />
         <main className="flex-1">{children}</main>
         <Footer />
+        <div className="goat-watermark">🐐</div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,19 +12,31 @@ export default function Home() {
   }, []);
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen bg-goat-beige text-goat-blue px-4 py-12">
-      <div className="bg-white p-8 rounded-xl shadow-md text-center max-w-xl" data-aos="fade-up">
-        <Image src="/images/logo.png" alt="Paper Goat Logo" width={240} height={240} className="mb-6 mx-auto" />
-        <h1 className="text-4xl font-bold mb-4 logo-text">Paper Goat</h1>
-        <p className="text-lg text-goat-black mb-6">
-          Social enterprise creating opportunities for NZ performers to develop their craft and give audiences greater access to creative, engaging performances.
-        </p>
-        <div className="flex justify-center gap-6">
-          <Link href="https://www.facebook.com/PaperGoatNz" target="_blank" className="text-goat-pink hover:underline">Facebook</Link>
-          <Link href="https://www.instagram.com/papergoatnz/" target="_blank" className="text-goat-pink hover:underline">Instagram</Link>
+      <main className="flex flex-col items-center justify-center min-h-screen px-4 py-12 gap-12">
+        <div className="bg-white text-goat-blue p-8 rounded-2xl shadow-xl max-w-xl mx-auto text-center card" data-aos="fade-up">
+          <Image src="/images/logo.png" alt="Paper Goat Logo" width={240} height={240} className="mb-6 mx-auto" />
+          <h1 className="text-5xl font-extrabold tracking-tight mb-4 logo-text text-center">Paper Goat</h1>
+          <p className="text-lg md:text-xl font-light leading-relaxed text-center text-goat-black">
+            Social enterprise creating opportunities for NZ performers to develop their craft and give audiences greater access to creative, engaging performances.
+          </p>
+          <div className="flex justify-center gap-6">
+            <Link href="https://www.facebook.com/PaperGoatNz" target="_blank" className="text-goat-pink hover:underline">Facebook</Link>
+            <Link href="https://www.instagram.com/papergoatnz/" target="_blank" className="text-goat-pink hover:underline">Instagram</Link>
+          </div>
+          <p className="mt-8 text-sm text-gray-500">Upcoming shows, workshops, blog, and shop coming soon.</p>
         </div>
-        <p className="mt-8 text-sm text-gray-500">Upcoming shows, workshops, blog, and shop coming soon.</p>
-      </div>
-    </main>
+        <section className="bg-goat-yellow text-goat-black py-12 w-full">
+          <div className="max-w-4xl mx-auto text-center px-4" data-aos="fade-up">
+            <h2 className="text-2xl font-bold mb-2">Upcoming Workshops</h2>
+            <p className="text-md">Learn, rehearse, and perform with Paper Goat.</p>
+          </div>
+        </section>
+        <section className="bg-goat-pink text-white py-12 w-full">
+          <div className="max-w-4xl mx-auto text-center px-4" data-aos="fade-up">
+            <h2 className="text-2xl font-bold mb-2">Upcoming Shows</h2>
+            <p className="text-md">Catch our next performances around NZ.</p>
+          </div>
+        </section>
+      </main>
   );
 }

--- a/src/app/shows/page.tsx
+++ b/src/app/shows/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import AOS from 'aos';
+import 'aos/dist/aos.css';
 import { useRouter } from 'next/navigation';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from '@/firebase/firebase.config';
@@ -13,6 +15,7 @@ export default function ShowsPage() {
   const router = useRouter();
 
   useEffect(() => {
+    AOS.init({ duration: 800 });
     (async () => {
       const data = await getShows();
       setShows(data);
@@ -35,8 +38,12 @@ export default function ShowsPage() {
         <p className="text-gray-500">No shows currently listed.</p>
       ) : (
         <div className="grid gap-10 md:grid-cols-2">
-          {shows.map(show => (
-            <div key={show.id} className="border rounded-lg overflow-hidden shadow-sm bg-white">
+            {shows.map(show => (
+              <div
+                key={show.id}
+                className="border rounded-lg overflow-hidden shadow-sm bg-white card"
+                data-aos="fade-up"
+              >
               <Image
                 src={show.imageUrl}
                 alt={show.title}
@@ -59,8 +66,18 @@ export default function ShowsPage() {
                 </a>
                 {isAdmin && (
                   <div className="flex gap-4 mt-2">
-                    <button onClick={() => router.push(`/admin/shows/edit/${show.id}`)}>Edit</button>
-                    <button onClick={() => handleDelete(show.id)}>Delete</button>
+                    <button
+                      onClick={() => router.push(`/admin/shows/edit/${show.id}`)}
+                      className="px-4 py-1 bg-goat-yellow text-black rounded-md text-sm hover:bg-yellow-400 transition"
+                    >
+                      ✏️ Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(show.id)}
+                      className="px-4 py-1 bg-red-500 text-white rounded-md text-sm hover:bg-red-600 transition"
+                    >
+                      🗑️ Delete
+                    </button>
                   </div>
                 )}
               </div>

--- a/src/app/workshops/page.tsx
+++ b/src/app/workshops/page.tsx
@@ -61,8 +61,18 @@ export default function WorkshopsPage() {
                 </a>
                 {isAdmin && (
                   <div className="flex gap-4 mt-4">
-                    <button onClick={() => router.push(`/admin/workshops/edit/${workshop.id}`)} className="text-goat-blue underline">Edit</button>
-                    <button onClick={() => handleDelete(workshop.id)} className="text-red-600 underline">Delete</button>
+                    <button
+                      onClick={() => router.push(`/admin/workshops/edit/${workshop.id}`)}
+                      className="px-4 py-1 bg-goat-yellow text-black rounded-md text-sm hover:bg-yellow-400 transition"
+                    >
+                      ✏️ Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(workshop.id)}
+                      className="px-4 py-1 bg-red-500 text-white rounded-md text-sm hover:bg-red-600 transition"
+                    >
+                      🗑️ Delete
+                    </button>
                   </div>
                 )}
               </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,11 @@
 export default function Footer() {
   return (
-    <footer className="bg-goat-black text-white py-8 text-sm mt-12">
+    <footer className="bg-goat-black/80 backdrop-blur-md text-white py-8 text-sm mt-12">
       <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4 px-6">
         <p>&copy; {new Date().getFullYear()} Paper Goat. Powered by improv & goats.</p>
         <div className="flex gap-4">
-          <a className="hover:text-goat-yellow" href="https://www.facebook.com/PaperGoatNz" target="_blank" rel="noopener noreferrer">Facebook</a>
-          <a className="hover:text-goat-yellow" href="https://www.instagram.com/papergoatnz/" target="_blank" rel="noopener noreferrer">Instagram</a>
+          <a className="hover:text-goat-yellow" href="https://www.facebook.com/PaperGoatNz" target="_blank" rel="noopener noreferrer">📘 Facebook</a>
+          <a className="hover:text-goat-yellow" href="https://www.instagram.com/papergoatnz/" target="_blank" rel="noopener noreferrer">📸 Instagram</a>
         </div>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,12 +4,12 @@ import Link from 'next/link';
 
 export default function Header() {
   return (
-    <header className="w-full py-4 px-6 bg-white border-b border-gray-200 shadow-sm">
+    <header className="w-full py-4 px-6 bg-white/80 backdrop-blur-md shadow-sm text-goat-blue">
       <div className="max-w-6xl mx-auto flex justify-between items-center">
-        <Link href="/" className="text-xl font-bold text-black">
+        <Link href="/" className="text-xl font-bold">
           🐐 Paper Goat
         </Link>
-        <nav className="flex gap-6 text-sm text-gray-700">
+        <nav className="flex gap-6 text-sm">
           <Link href="/shows" className="hover:underline">
             Shows
           </Link>
@@ -17,7 +17,7 @@ export default function Header() {
             Workshops
           </Link>
           <Link href="https://papergoat.digitees.co.nz" className="hover:underline">
-            Shop
+            🛍️ Shop
           </Link>
           <Link href="/blog" className="hover:underline">
             Blog


### PR DESCRIPTION
## Summary
- update layout with blue background and goat watermark
- revamp header and footer with glass look and icons
- style homepage card and add colorful sections
- smooth out transitions in global styles
- add animated cards and admin buttons across pages

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_687a0d5e48e88329b4ff9370f795a7da