### PR TITLE
Add workshop signup form and admin dashboard

### DIFF
--- a/src/app/admin/workshop-signups/page.tsx
+++ b/src/app/admin/workshop-signups/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '@/firebase/firebase.config';
+import WithAdminProtection from '@/components/WithAdminProtection';
+import WorkshopDropdown, { WorkshopOption } from '@/components/WorkshopDropdown';
+import WorkshopSignupsTable, { SignupRecord } from '@/components/WorkshopSignupsTable';
+
+function WorkshopSignupsDashboard() {
+  const [workshops, setWorkshops] = useState<WorkshopOption[]>([]);
+  const [selectedId, setSelectedId] = useState('');
+  const [signups, setSignups] = useState<SignupRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const loadWorkshops = async () => {
+      const snap = await getDocs(collection(db, 'workshops'));
+      const list: WorkshopOption[] = [];
+      snap.forEach(doc => {
+        const data = doc.data();
+        list.push({ id: doc.id, title: data.title || doc.id });
+      });
+      setWorkshops(list);
+    };
+    loadWorkshops();
+  }, []);
+
+  const loadSignups = async (id: string) => {
+    setSelectedId(id);
+    if (!id) { setSignups([]); return; }
+    setLoading(true);
+    const snap = await getDocs(collection(db, 'workshops', id, 'signups'));
+    const list: SignupRecord[] = [];
+    snap.forEach(doc => {
+      const data = doc.data();
+      list.push({
+        id: doc.id,
+        firstName: data.firstName || '',
+        lastName: data.lastName || '',
+        email: data.email || '',
+        phone: data.phone || '',
+      });
+    });
+    setSignups(list);
+    setLoading(false);
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-12">
+      <h1 className="text-2xl font-bold mb-4">Workshop Signups</h1>
+      <WorkshopDropdown workshops={workshops} value={selectedId} onChange={loadSignups} />
+      {loading ? <p className="mt-4">Loading...</p> : <div className="mt-4"><WorkshopSignupsTable signups={signups} /></div>}
+    </div>
+  );
+}
+
+export default WithAdminProtection(WorkshopSignupsDashboard);

--- a/src/app/workshops/[id]/signup/page.tsx
+++ b/src/app/workshops/[id]/signup/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '@/firebase/firebase.config';
+import { addWorkshopSignup } from '@/firebase/addWorkshopSignup';
+import WorkshopSignUpForm, { SignUpFormValues } from '@/components/WorkshopSignUpForm';
+
+export default function WorkshopSignupPage() {
+  const { id } = useParams<{ id: string }>();
+  const [title, setTitle] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDoc(doc(db, 'workshops', id));
+      if (snap.exists()) {
+        const data = snap.data();
+        setTitle(data.title || '');
+      }
+      setLoading(false);
+    };
+    if (id) load();
+  }, [id]);
+
+  const handleSubmit = async (values: SignUpFormValues) => {
+    if (!id) return;
+    await addWorkshopSignup(id, values);
+    setMessage('Thanks for signing up!');
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-md mx-auto px-6 py-12">
+      <h1 className="text-2xl font-bold mb-4">Sign Up for {title}</h1>
+      {message ? (
+        <p>{message}</p>
+      ) : (
+        <WorkshopSignUpForm onSubmit={handleSubmit} />
+      )}
+    </div>
+  );
+}

--- a/src/app/workshops/page.tsx
+++ b/src/app/workshops/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import AOS from 'aos';
 import 'aos/dist/aos.css';
@@ -51,14 +52,9 @@ export default function WorkshopsPage() {
                 <h2 className="text-heading-lg mb-2">{workshop.title}</h2>
                 <p className="text-sm text-gray-500">{workshop.venue}</p>
                 <p className="mb-4">{workshop.description}</p>
-                <a
-                  href={workshop.signupLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="btn btn-primary"
-                >
-                  Sign up
-                </a>
+                <Link href={`/workshops/${workshop.id}/signup`}>
+                  <button className="btn btn-primary">Sign Up</button>
+                </Link>
                 {isAdmin && (
                   <div className="flex gap-4 mt-4">
                     <button

--- a/src/components/WorkshopDropdown.tsx
+++ b/src/components/WorkshopDropdown.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+export interface WorkshopOption {
+  id: string;
+  title: string;
+}
+
+export default function WorkshopDropdown({
+  workshops,
+  value,
+  onChange,
+}: {
+  workshops: WorkshopOption[];
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <select
+      className="border rounded p-2"
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    >
+      <option value="">Select workshop</option>
+      {workshops.map(w => (
+        <option key={w.id} value={w.id}>
+          {w.title}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/WorkshopSignUpForm.tsx
+++ b/src/components/WorkshopSignUpForm.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { useState, FormEvent } from 'react';
+
+export interface SignUpFormValues {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+}
+
+export default function WorkshopSignUpForm({ onSubmit }: { onSubmit: (values: SignUpFormValues) => Promise<void>; }) {
+  const [values, setValues] = useState<SignUpFormValues>({ firstName: '', lastName: '', email: '', phone: '' });
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    await onSubmit(values);
+    setSubmitting(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        name="firstName"
+        placeholder="First Name"
+        className="w-full border rounded p-2"
+        value={values.firstName}
+        onChange={handleChange}
+        required
+      />
+      <input
+        name="lastName"
+        placeholder="Last Name"
+        className="w-full border rounded p-2"
+        value={values.lastName}
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="email"
+        name="email"
+        placeholder="Email"
+        className="w-full border rounded p-2"
+        value={values.email}
+        onChange={handleChange}
+        required
+      />
+      <input
+        name="phone"
+        placeholder="Phone (optional)"
+        className="w-full border rounded p-2"
+        value={values.phone ?? ''}
+        onChange={handleChange}
+      />
+      <button type="submit" disabled={submitting} className="btn btn-primary">
+        {submitting ? 'Submitting...' : 'Sign Up'}
+      </button>
+    </form>
+  );
+}

--- a/src/components/WorkshopSignupsTable.tsx
+++ b/src/components/WorkshopSignupsTable.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+export interface SignupRecord {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+}
+
+export default function WorkshopSignupsTable({ signups }: { signups: SignupRecord[] }) {
+  if (signups.length === 0) {
+    return <p>No signups yet.</p>;
+  }
+
+  return (
+    <table className="min-w-full border border-collapse">
+      <thead>
+        <tr>
+          <th className="border p-2">First</th>
+          <th className="border p-2">Last</th>
+          <th className="border p-2">Email</th>
+          <th className="border p-2">Phone</th>
+        </tr>
+      </thead>
+      <tbody>
+        {signups.map(s => (
+          <tr key={s.id}>
+            <td className="border p-2">{s.firstName}</td>
+            <td className="border p-2">{s.lastName}</td>
+            <td className="border p-2">{s.email}</td>
+            <td className="border p-2">{s.phone || '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/firebase/addWorkshopSignup.ts
+++ b/src/firebase/addWorkshopSignup.ts
@@ -1,0 +1,14 @@
+import { db } from './firebase.config';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+
+export interface WorkshopSignupData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+}
+
+export async function addWorkshopSignup(workshopId: string, data: WorkshopSignupData) {
+  const ref = collection(db, 'workshops', workshopId, 'signups');
+  await addDoc(ref, { ...data, timestamp: serverTimestamp() });
+}


### PR DESCRIPTION
## Summary
- create Firestore helper to save workshop signups
- create signup form component and workshop dropdown utilities
- add table to show workshop signups
- implement `/workshops/[id]/signup` page using the form
- add admin page `/admin/workshop-signups` to review signups
- update workshop card to link to signup page

## Testing
- `npm run lint` *(fails: Unexpected any in other files)*

------
https://chatgpt.com/codex/tasks/task_e_687ae4b15be08329a5cce20055879ea7